### PR TITLE
chore: upgrade rand 0.8 → 0.9 (breaking API migration)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,5 @@ jobs:
           cargo test --test test_detailed_race_logging
       - name: Build examples (also use rand)
         run: cargo build --examples
-      - name: Stress module tests
-        run: cargo test --test stress
+      - name: Stress module tests (uses rand 0.9)
+        run: cargo test --test stress_tests -- --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Library tests
+        run: cargo test --lib
+      - name: Integration tests (rand 0.9 call sites)
+        run: |
+          set -euo pipefail
+          cargo test --test model_based
+          cargo test --test conflict_detection
+          cargo test --test query_fuzzing
+          cargo test --test test_concurrent_insert
+          cargo test --test test_insert_delete_race
+          cargo test --test test_model_based_flaky_reproducer
+          cargo test --test test_detailed_race_logging
+      - name: Build examples (also use rand)
+        run: cargo build --examples
+      - name: Stress module tests
+        run: cargo test --test stress

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,17 +54,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -167,20 +156,19 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -188,11 +176,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom",
 ]
 
 [[package]]
@@ -275,7 +263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -324,12 +312,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ web-ui = ["tiny_http"]
 
 [dev-dependencies]
 tempfile = "3.8"
-rand = "0.8"
+rand = "0.9"
 
 [profile.release]
 # Optimize for size

--- a/examples/bench_all.rs
+++ b/examples/bench_all.rs
@@ -9,9 +9,9 @@ use tempfile::TempDir;
 fn random_string(length: usize) -> String {
     use rand::Rng;
     const CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     (0..length)
-        .map(|_| CHARS[rng.gen_range(0..CHARS.len())] as char)
+        .map(|_| CHARS[rng.random_range(0..CHARS.len())] as char)
         .collect()
 }
 

--- a/examples/bench_batch_reuse.rs
+++ b/examples/bench_batch_reuse.rs
@@ -6,9 +6,9 @@ use tempfile::TempDir;
 fn random_string(length: usize) -> String {
     use rand::Rng;
     const CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     (0..length)
-        .map(|_| CHARS[rng.gen_range(0..CHARS.len())] as char)
+        .map(|_| CHARS[rng.random_range(0..CHARS.len())] as char)
         .collect()
 }
 

--- a/examples/bench_insert1000_like_go.rs
+++ b/examples/bench_insert1000_like_go.rs
@@ -6,9 +6,9 @@ use tempfile::TempDir;
 fn random_string(length: usize) -> String {
     use rand::Rng;
     const CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     (0..length)
-        .map(|_| CHARS[rng.gen_range(0..CHARS.len())] as char)
+        .map(|_| CHARS[rng.random_range(0..CHARS.len())] as char)
         .collect()
 }
 

--- a/examples/bench_insert_only.rs
+++ b/examples/bench_insert_only.rs
@@ -6,9 +6,9 @@ use tempfile::TempDir;
 fn random_string(length: usize) -> String {
     use rand::Rng;
     const CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     (0..length)
-        .map(|_| CHARS[rng.gen_range(0..CHARS.len())] as char)
+        .map(|_| CHARS[rng.random_range(0..CHARS.len())] as char)
         .collect()
 }
 

--- a/tests/model_based.rs
+++ b/tests/model_based.rs
@@ -3,7 +3,7 @@ use jasonisnthappy::core::database::Database;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use tempfile::TempDir;
-use rand::{thread_rng, Rng};
+use rand::Rng;
 
 #[derive(Debug, Clone)]
 struct TruthModel {
@@ -171,7 +171,7 @@ fn test_model_based_correctness() {
 
     let db = Database::open(db_path.to_str().unwrap()).unwrap();
     let mut truth = TruthModel::new();
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     const OPERATIONS: usize = 1000;
     let mut insert_count = 0;
@@ -183,7 +183,7 @@ fn test_model_based_correctness() {
     println!("Running {} random operations with model-based verification...", OPERATIONS);
 
     for i in 0..OPERATIONS {
-        let operation = rng.gen_range(0..4);
+        let operation = rng.random_range(0..4);
         let collection_name = "test_collection";
 
         match operation {
@@ -193,7 +193,7 @@ fn test_model_based_correctness() {
                     "_id": doc_id,
                     "type": "test",
                     "iteration": i,
-                    "value": rng.gen_range(0..1000),
+                    "value": rng.random_range(0..1000),
                     "timestamp": std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap()
@@ -218,14 +218,14 @@ fn test_model_based_correctness() {
             1 => {
                 let all_docs = truth.find_all(collection_name);
                 if !all_docs.is_empty() {
-                    let random_doc = &all_docs[rng.gen_range(0..all_docs.len())];
+                    let random_doc = &all_docs[rng.random_range(0..all_docs.len())];
                     if let Some(doc_id) = random_doc.get("_id").and_then(|v| v.as_str()) {
                         let updates = json!({
                             "updated_at": std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .unwrap()
                                 .as_secs(),
-                            "value": rng.gen_range(0..1000),
+                            "value": rng.random_range(0..1000),
                         });
 
                         let mut tx = db.begin().unwrap();
@@ -248,7 +248,7 @@ fn test_model_based_correctness() {
             2 => {
                 let all_docs = truth.find_all(collection_name);
                 if !all_docs.is_empty() {
-                    let random_doc = &all_docs[rng.gen_range(0..all_docs.len())];
+                    let random_doc = &all_docs[rng.random_range(0..all_docs.len())];
                     if let Some(doc_id) = random_doc.get("_id").and_then(|v| v.as_str()) {
                         let mut tx = db.begin().unwrap();
                         let mut collection = tx.collection(collection_name).unwrap();
@@ -331,7 +331,7 @@ fn test_model_based_with_crash() {
     let db_path_str = db_path.to_str().unwrap();
 
     let mut truth = TruthModel::new();
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     const CRASH_INTERVAL: usize = 100;
     const TOTAL_OPERATIONS: usize = 500;
@@ -351,7 +351,7 @@ fn test_model_based_with_crash() {
                 "_id": doc_id,
                 "round": round,
                 "iter": i,
-                "value": rng.gen_range(0..1000),
+                "value": rng.random_range(0..1000),
             });
 
             match collection.insert(doc.clone()) {
@@ -421,11 +421,11 @@ fn test_model_based_concurrent() {
             let truth = Arc::clone(&truth);
 
             thread::spawn(move || {
-                let mut rng = thread_rng();
+                let mut rng = rand::rng();
                 let collection_name = "concurrent_test";
 
                 for i in 0..OPS_PER_WORKER {
-                    let operation = rng.gen_range(0..3);
+                    let operation = rng.random_range(0..3);
 
                     match operation {
                         0 => {
@@ -434,7 +434,7 @@ fn test_model_based_concurrent() {
                                 "_id": doc_id.clone(),
                                 "worker": worker_id,
                                 "iteration": i,
-                                "value": rng.gen_range(0..1000),
+                                "value": rng.random_range(0..1000),
                             });
 
                             let mut tx = db.begin().unwrap();
@@ -453,11 +453,11 @@ fn test_model_based_concurrent() {
                             };
 
                             if !truth_docs.is_empty() {
-                                let random_doc = &truth_docs[rng.gen_range(0..truth_docs.len())];
+                                let random_doc = &truth_docs[rng.random_range(0..truth_docs.len())];
                                 if let Some(doc_id_str) = random_doc.get("_id").and_then(|v| v.as_str()) {
                                     let doc_id = doc_id_str.to_string();
                                     let updates = json!({
-                                        "value": rng.gen_range(0..1000),
+                                        "value": rng.random_range(0..1000),
                                     });
 
                                     let mut tx = db.begin().unwrap();
@@ -478,7 +478,7 @@ fn test_model_based_concurrent() {
                             };
 
                             if !truth_docs.is_empty() && i > 10 {
-                                let random_doc = &truth_docs[rng.gen_range(0..truth_docs.len())];
+                                let random_doc = &truth_docs[rng.random_range(0..truth_docs.len())];
                                 if let Some(doc_id_str) = random_doc.get("_id").and_then(|v| v.as_str()) {
                                     let doc_id = doc_id_str.to_string();
 

--- a/tests/query_fuzzing.rs
+++ b/tests/query_fuzzing.rs
@@ -35,12 +35,12 @@ fn test_query_parser_fuzzing() {
 }
 
 fn test_random_binary_garbage() -> usize {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut count = 0;
 
     for i in 0..1000 {
         let length = 1 + (i % 1000);
-        let garbage: Vec<u8> = (0..length).map(|_| rng.gen()).collect();
+        let garbage: Vec<u8> = (0..length).map(|_| rng.random()).collect();
 
         let query = String::from_utf8_lossy(&garbage);
         test_parse_no_fail(&query, "random binary garbage");

--- a/tests/stress/concurrency.rs
+++ b/tests/stress/concurrency.rs
@@ -703,7 +703,7 @@ fn run_combined_worker(db_path: &str, process_id: usize) {
         let db = Arc::clone(&db);
 
         let handle = thread::spawn(move || {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             use rand::Rng;
 
             for op_id in 0..OPS_PER_THREAD {
@@ -722,7 +722,7 @@ fn run_combined_worker(db_path: &str, process_id: usize) {
                     "process": process_id,
                     "thread": thread_id,
                     "op": op_id,
-                    "value": rng.gen_range(0..1000),
+                    "value": rng.random_range(0..1000),
                 });
 
                 let _ = collection.insert(doc);

--- a/tests/stress/mvcc.rs
+++ b/tests/stress/mvcc.rs
@@ -145,12 +145,12 @@ fn test_lru_cache_eviction() {
         tx.commit().unwrap();
     }
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let access_count = 10000;
     let mut hits = 0;
 
     for _i in 0..access_count {
-        let doc_id = format!("doc_{}", rng.gen_range(0..5000));
+        let doc_id = format!("doc_{}", rng.random_range(0..5000));
 
         let mut tx = db.begin().unwrap();
         let coll = tx.collection("cache_test").unwrap();

--- a/tests/test_concurrent_insert.rs
+++ b/tests/test_concurrent_insert.rs
@@ -151,12 +151,12 @@ fn test_concurrent_inserts_with_updates_deletes() {
         let final_state = final_state.clone();
 
         let handle = thread::spawn(move || {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let mut local_ids: Vec<String> = Vec::new();
             let mut local_final: HashSet<String> = HashSet::new();
 
             for _ in 0..ops_per_thread {
-                let roll: f64 = rand::Rng::gen(&mut rng);
+                let roll: f64 = rand::Rng::random(&mut rng);
 
                 if roll < 0.70 || local_ids.is_empty() {
                     // INSERT
@@ -181,7 +181,7 @@ fn test_concurrent_inserts_with_updates_deletes() {
                     }
                 } else if roll < 0.90 {
                     // UPDATE - pick random local doc
-                    if let Some(doc_id) = local_ids.get(rand::Rng::gen_range(&mut rng, 0..local_ids.len())) {
+                    if let Some(doc_id) = local_ids.get(rand::Rng::random_range(&mut rng, 0..local_ids.len())) {
                         let mut tx = db.begin().expect("begin failed");
                         let mut coll = tx.collection("test").expect("collection failed");
 
@@ -193,7 +193,7 @@ fn test_concurrent_inserts_with_updates_deletes() {
                     }
                 } else {
                     // DELETE - pick random local doc
-                    let idx = rand::Rng::gen_range(&mut rng, 0..local_ids.len());
+                    let idx = rand::Rng::random_range(&mut rng, 0..local_ids.len());
                     let doc_id = local_ids[idx].clone();
 
                     let mut tx = db.begin().expect("begin failed");
@@ -294,10 +294,10 @@ fn test_cross_thread_operations() {
         let shared_ids = shared_ids.clone();
 
         let handle = thread::spawn(move || {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
 
             for _ in 0..ops_per_thread {
-                let roll: f64 = rand::Rng::gen(&mut rng);
+                let roll: f64 = rand::Rng::random(&mut rng);
 
                 if roll < 0.60 {
                     // INSERT (60%)
@@ -328,7 +328,7 @@ fn test_cross_thread_operations() {
                             None
                         } else {
                             let vec: Vec<_> = ids.iter().cloned().collect();
-                            Some(vec[rand::Rng::gen_range(&mut rng, 0..vec.len())].clone())
+                            Some(vec[rand::Rng::random_range(&mut rng, 0..vec.len())].clone())
                         }
                     };
 
@@ -350,7 +350,7 @@ fn test_cross_thread_operations() {
                             None
                         } else {
                             let vec: Vec<_> = ids.iter().cloned().collect();
-                            Some(vec[rand::Rng::gen_range(&mut rng, 0..vec.len())].clone())
+                            Some(vec[rand::Rng::random_range(&mut rng, 0..vec.len())].clone())
                         }
                     };
 

--- a/tests/test_detailed_race_logging.rs
+++ b/tests/test_detailed_race_logging.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
-use rand::{thread_rng, Rng};
+use rand::Rng;
 
 #[derive(Debug, Clone)]
 struct Operation {
@@ -39,10 +39,10 @@ fn test_with_detailed_logging() {
                 let op_log = Arc::clone(&op_log);
 
                 thread::spawn(move || {
-                    let mut rng = thread_rng();
+                    let mut rng = rand::rng();
 
                     for i in 0..50 {
-                        let operation = rng.gen_range(0..3);
+                        let operation = rng.random_range(0..3);
 
                         match operation {
                             0 => {
@@ -120,8 +120,8 @@ fn test_with_detailed_logging() {
                                 };
 
                                 if !truth_docs.is_empty() {
-                                    let doc_id = truth_docs[rng.gen_range(0..truth_docs.len())].clone();
-                                    let updates = json!({"value": rng.gen_range(0..1000)});
+                                    let doc_id = truth_docs[rng.random_range(0..truth_docs.len())].clone();
+                                    let updates = json!({"value": rng.random_range(0..1000)});
 
                                     let mut tx = db.begin().unwrap();
                                     let mut collection = tx.collection("test").unwrap();
@@ -146,7 +146,7 @@ fn test_with_detailed_logging() {
                                 };
 
                                 if !truth_docs.is_empty() && i > 10 {
-                                    let doc_id = truth_docs[rng.gen_range(0..truth_docs.len())].clone();
+                                    let doc_id = truth_docs[rng.random_range(0..truth_docs.len())].clone();
 
                                     let timestamp_us = SystemTime::now()
                                         .duration_since(UNIX_EPOCH)

--- a/tests/test_insert_delete_race.rs
+++ b/tests/test_insert_delete_race.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use tempfile::TempDir;
-use rand::{thread_rng, Rng};
+use rand::Rng;
 
 #[test]
 fn test_insert_delete_concurrent_same_docs() {
@@ -34,10 +34,10 @@ fn test_insert_delete_concurrent_same_docs() {
                 let truth = Arc::clone(&truth);
 
                 thread::spawn(move || {
-                    let mut rng = thread_rng();
+                    let mut rng = rand::rng();
 
                     for i in 0..50 {
-                        let op = rng.gen_range(0..2);
+                        let op = rng.random_range(0..2);
 
                         match op {
                             0 => {
@@ -61,7 +61,7 @@ fn test_insert_delete_concurrent_same_docs() {
                                 };
 
                                 if !truth_snapshot.is_empty() && i > 5 {
-                                    let doc_id = &truth_snapshot[rng.gen_range(0..truth_snapshot.len())];
+                                    let doc_id = &truth_snapshot[rng.random_range(0..truth_snapshot.len())];
 
                                     let mut tx = db.begin().unwrap();
                                     let mut collection = tx.collection("test").unwrap();
@@ -147,10 +147,10 @@ fn test_insert_update_delete_pattern() {
                 let truth = Arc::clone(&truth);
 
                 thread::spawn(move || {
-                    let mut rng = thread_rng();
+                    let mut rng = rand::rng();
 
                     for i in 0..OPS_PER_WORKER {
-                        let operation = rng.gen_range(0..3);
+                        let operation = rng.random_range(0..3);
 
                         match operation {
                             0 => {
@@ -160,7 +160,7 @@ fn test_insert_update_delete_pattern() {
                                     "_id": doc_id.clone(),
                                     "worker": worker_id,
                                     "iteration": i,
-                                    "value": rng.gen_range(0..1000),
+                                    "value": rng.random_range(0..1000),
                                 });
 
                                 let mut tx = db.begin().unwrap();
@@ -179,8 +179,8 @@ fn test_insert_update_delete_pattern() {
                                 };
 
                                 if !truth_docs.is_empty() {
-                                    let doc_id = &truth_docs[rng.gen_range(0..truth_docs.len())];
-                                    let updates = json!({"value": rng.gen_range(0..1000)});
+                                    let doc_id = &truth_docs[rng.random_range(0..truth_docs.len())];
+                                    let updates = json!({"value": rng.random_range(0..1000)});
 
                                     let mut tx = db.begin().unwrap();
                                     let mut collection = tx.collection("concurrent_test").unwrap();
@@ -205,7 +205,7 @@ fn test_insert_update_delete_pattern() {
                                 };
 
                                 if !truth_docs.is_empty() && i > 10 {
-                                    let doc_id = truth_docs[rng.gen_range(0..truth_docs.len())].clone();
+                                    let doc_id = truth_docs[rng.random_range(0..truth_docs.len())].clone();
 
                                     let mut tx = db.begin().unwrap();
                                     let mut collection = tx.collection("concurrent_test").unwrap();

--- a/tests/test_model_based_flaky_reproducer.rs
+++ b/tests/test_model_based_flaky_reproducer.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use tempfile::TempDir;
-use rand::{thread_rng, Rng};
+use rand::Rng;
 
 #[derive(Debug, Clone)]
 struct TruthModel {
@@ -129,11 +129,11 @@ fn test_reproduce_flaky_concurrent() {
                 let operations_log = Arc::clone(&operations_log);
 
                 thread::spawn(move || {
-                    let mut rng = thread_rng();
+                    let mut rng = rand::rng();
                     let collection_name = "concurrent_test";
 
                     for i in 0..OPS_PER_WORKER {
-                        let operation = rng.gen_range(0..3);
+                        let operation = rng.random_range(0..3);
 
                         match operation {
                             0 => {
@@ -143,7 +143,7 @@ fn test_reproduce_flaky_concurrent() {
                                     "_id": doc_id.clone(),
                                     "worker": worker_id,
                                     "iteration": i,
-                                    "value": rng.gen_range(0..1000),
+                                    "value": rng.random_range(0..1000),
                                 });
 
                                 let mut tx = db.begin().unwrap();
@@ -176,10 +176,10 @@ fn test_reproduce_flaky_concurrent() {
                                 };
 
                                 if !truth_docs.is_empty() {
-                                    let random_doc = &truth_docs[rng.gen_range(0..truth_docs.len())];
+                                    let random_doc = &truth_docs[rng.random_range(0..truth_docs.len())];
                                     if let Some(doc_id_str) = random_doc.get("_id").and_then(|v| v.as_str()) {
                                         let doc_id = doc_id_str.to_string();
-                                        let updates = json!({"value": rng.gen_range(0..1000)});
+                                        let updates = json!({"value": rng.random_range(0..1000)});
 
                                         let mut tx = db.begin().unwrap();
                                         let mut collection = tx.collection(collection_name).unwrap();
@@ -199,7 +199,7 @@ fn test_reproduce_flaky_concurrent() {
                                 };
 
                                 if !truth_docs.is_empty() && i > 10 {
-                                    let random_doc = &truth_docs[rng.gen_range(0..truth_docs.len())];
+                                    let random_doc = &truth_docs[rng.random_range(0..truth_docs.len())];
                                     if let Some(doc_id_str) = random_doc.get("_id").and_then(|v| v.as_str()) {
                                         let doc_id = doc_id_str.to_string();
 

--- a/tests/test_paranoid_soak.rs
+++ b/tests/test_paranoid_soak.rs
@@ -17,8 +17,8 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use rand::{thread_rng, Rng, seq::SliceRandom};
-use rand::distributions::Alphanumeric;
+use rand::{Rng, seq::IndexedRandom};
+use rand::distr::{Alphanumeric, SampleString};
 
 // ============================================================================
 // CONFIGURATION
@@ -120,7 +120,7 @@ impl GroundTruth {
             if ids.is_empty() {
                 None
             } else {
-                let mut rng = thread_rng();
+                let mut rng = rand::rng();
                 Some(ids.choose(&mut rng).unwrap().to_string())
             }
         })
@@ -140,24 +140,20 @@ impl GroundTruth {
 // ============================================================================
 
 fn generate_random_string(len: usize) -> String {
-    thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(len)
-        .map(char::from)
-        .collect()
+    Alphanumeric.sample_string(&mut rand::rng(), len)
 }
 
 fn pick<'a>(choices: &[&'a str]) -> &'a str {
-    choices[thread_rng().gen_range(0..choices.len())]
+    choices[rand::rng().random_range(0..choices.len())]
 }
 
 fn generate_user_doc(id: &str, size_class: &str) -> Value {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     let bio_size = match size_class {
-        "small" => rng.gen_range(10..500),
-        "medium" => rng.gen_range(5_000..50_000),
-        "large" => rng.gen_range(500_000..2_000_000),
+        "small" => rng.random_range(10..500),
+        "medium" => rng.random_range(5_000..50_000),
+        "large" => rng.random_range(500_000..2_000_000),
         _ => 100,
     };
 
@@ -172,32 +168,32 @@ fn generate_user_doc(id: &str, size_class: &str) -> Value {
             "first": generate_random_string(8),
             "last": generate_random_string(12),
         },
-        "age": rng.gen_range(18..80),
+        "age": rng.random_range(18..80),
         "created_at": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs(),
         "preferences": {
             "theme": theme,
             "language": language,
-            "notifications": rng.gen_bool(0.7),
+            "notifications": rng.random_bool(0.7),
         },
         "bio": generate_random_string(bio_size),
-        "tags": (0..rng.gen_range(1..10)).map(|_| generate_random_string(8)).collect::<Vec<_>>(),
+        "tags": (0..rng.random_range(1..10)).map(|_| generate_random_string(8)).collect::<Vec<_>>(),
     })
 }
 
 fn generate_product_doc(id: &str, size_class: &str) -> Value {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     let description_size = match size_class {
-        "small" => rng.gen_range(50..500),
-        "medium" => rng.gen_range(10_000..100_000),
-        "large" => rng.gen_range(500_000..2_500_000),
+        "small" => rng.random_range(50..500),
+        "medium" => rng.random_range(10_000..100_000),
+        "large" => rng.random_range(500_000..2_500_000),
         _ => 200,
     };
 
     let num_images = match size_class {
-        "small" => rng.gen_range(1..3),
-        "medium" => rng.gen_range(5..20),
-        "large" => rng.gen_range(20..50),
+        "small" => rng.random_range(1..3),
+        "medium" => rng.random_range(5..20),
+        "large" => rng.random_range(20..50),
         _ => 2,
     };
 
@@ -209,32 +205,32 @@ fn generate_product_doc(id: &str, size_class: &str) -> Value {
         "type": "product",
         "sku": format!("SKU-{}", generate_random_string(10)),
         "name": generate_random_string(20),
-        "price": rng.gen_range(1.0..10000.0_f64),
+        "price": rng.random_range(1.0..10000.0_f64),
         "currency": currency,
         "category": category,
-        "in_stock": rng.gen_bool(0.8),
-        "quantity": rng.gen_range(0..1000),
+        "in_stock": rng.random_bool(0.8),
+        "quantity": rng.random_range(0..1000),
         "description": generate_random_string(description_size),
         "images": (0..num_images).map(|i| json!({
             "url": format!("https://cdn.example.com/products/{}/{}.jpg", id, i),
             "alt": generate_random_string(20),
-            "width": thread_rng().gen_range(100..4000),
-            "height": thread_rng().gen_range(100..4000),
+            "width": rand::rng().random_range(100..4000),
+            "height": rand::rng().random_range(100..4000),
         })).collect::<Vec<_>>(),
         "ratings": {
-            "average": rng.gen_range(1.0..5.0_f64),
-            "count": rng.gen_range(0..10000),
+            "average": rng.random_range(1.0..5.0_f64),
+            "count": rng.random_range(0..10000),
         },
     })
 }
 
 fn generate_order_doc(id: &str, size_class: &str) -> Value {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     let num_items = match size_class {
-        "small" => rng.gen_range(1..5),
-        "medium" => rng.gen_range(10..100),
-        "large" => rng.gen_range(500..2000),
+        "small" => rng.random_range(1..5),
+        "medium" => rng.random_range(10..100),
+        "large" => rng.random_range(500..2000),
         _ => 3,
     };
 
@@ -245,23 +241,23 @@ fn generate_order_doc(id: &str, size_class: &str) -> Value {
     json!({
         "_id": id,
         "type": "order",
-        "user_id": format!("user_{}", rng.gen_range(1..100000)),
+        "user_id": format!("user_{}", rng.random_range(1..100000)),
         "status": status,
         "created_at": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs(),
         "shipping_address": {
-            "street": format!("{} {} St", rng.gen_range(1..9999), generate_random_string(10)),
+            "street": format!("{} {} St", rng.random_range(1..9999), generate_random_string(10)),
             "city": generate_random_string(12),
             "state": generate_random_string(2).to_uppercase(),
-            "zip": format!("{:05}", rng.gen_range(10000..99999)),
+            "zip": format!("{:05}", rng.random_range(10000..99999)),
             "country": "US",
         },
         "items": (0..num_items).map(|_| json!({
-            "product_id": format!("prod_{}", thread_rng().gen_range(1..50000)),
-            "quantity": thread_rng().gen_range(1..10),
-            "price": thread_rng().gen_range(1.0..500.0_f64),
+            "product_id": format!("prod_{}", rand::rng().random_range(1..50000)),
+            "quantity": rand::rng().random_range(1..10),
+            "price": rand::rng().random_range(1.0..500.0_f64),
             "name": generate_random_string(15),
         })).collect::<Vec<_>>(),
-        "total": rng.gen_range(10.0..5000.0_f64),
+        "total": rng.random_range(10.0..5000.0_f64),
         "payment": {
             "method": payment_method,
             "status": payment_status,
@@ -270,12 +266,12 @@ fn generate_order_doc(id: &str, size_class: &str) -> Value {
 }
 
 fn generate_event_doc(id: &str, size_class: &str) -> Value {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     let payload_size = match size_class {
-        "small" => rng.gen_range(50..500),
-        "medium" => rng.gen_range(5_000..50_000),
-        "large" => rng.gen_range(500_000..3_000_000),
+        "small" => rng.random_range(50..500),
+        "medium" => rng.random_range(5_000..50_000),
+        "large" => rng.random_range(500_000..3_000_000),
         _ => 100,
     };
 
@@ -290,7 +286,7 @@ fn generate_event_doc(id: &str, size_class: &str) -> Value {
         "type": "event",
         "event_type": event_type,
         "timestamp": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64,
-        "user_id": format!("user_{}", rng.gen_range(1..100000)),
+        "user_id": format!("user_{}", rng.random_range(1..100000)),
         "session_id": generate_random_string(32),
         "device": {
             "type": device_type,
@@ -300,19 +296,19 @@ fn generate_event_doc(id: &str, size_class: &str) -> Value {
         "location": {
             "country": country,
             "city": generate_random_string(10),
-            "ip": format!("{}.{}.{}.{}", rng.gen_range(1..255), rng.gen_range(0..255), rng.gen_range(0..255), rng.gen_range(0..255)),
+            "ip": format!("{}.{}.{}.{}", rng.random_range(1..255), rng.random_range(0..255), rng.random_range(0..255), rng.random_range(0..255)),
         },
         "payload": generate_random_string(payload_size),
     })
 }
 
 fn generate_analytics_doc(id: &str, size_class: &str) -> Value {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     let num_data_points = match size_class {
-        "small" => rng.gen_range(10..100),
-        "medium" => rng.gen_range(500..5000),
-        "large" => rng.gen_range(10000..50000),
+        "small" => rng.random_range(10..100),
+        "medium" => rng.random_range(500..5000),
+        "large" => rng.random_range(10000..50000),
         _ => 50,
     };
 
@@ -330,21 +326,21 @@ fn generate_analytics_doc(id: &str, size_class: &str) -> Value {
         "aggregation": aggregation,
         "data_points": (0..num_data_points).map(|i| json!({
             "timestamp": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() - (i * 3600),
-            "value": thread_rng().gen_range(0.0..10000.0_f64),
-            "count": thread_rng().gen_range(0..100000),
+            "value": rand::rng().random_range(0.0..10000.0_f64),
+            "count": rand::rng().random_range(0..100000),
         })).collect::<Vec<_>>(),
         "summary": {
-            "total": rng.gen_range(0.0..1000000.0_f64),
-            "average": rng.gen_range(0.0..10000.0_f64),
-            "min": rng.gen_range(0.0..100.0_f64),
-            "max": rng.gen_range(100.0..100000.0_f64),
+            "total": rng.random_range(0.0..1000000.0_f64),
+            "average": rng.random_range(0.0..10000.0_f64),
+            "min": rng.random_range(0.0..100.0_f64),
+            "max": rng.random_range(100.0..100000.0_f64),
         },
     })
 }
 
 fn generate_document(collection: &str, id: &str) -> Value {
-    let mut rng = thread_rng();
-    let roll: f64 = rng.gen();
+    let mut rng = rand::rng();
+    let roll: f64 = rng.random();
 
     let size_class = if roll < SMALL_DOC_CHANCE {
         "small"
@@ -365,10 +361,10 @@ fn generate_document(collection: &str, id: &str) -> Value {
 }
 
 fn generate_update() -> Value {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
     json!({
         "updated_at": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs(),
-        "update_note": generate_random_string(rng.gen_range(10..100)),
+        "update_note": generate_random_string(rng.random_range(10..100)),
     })
 }
 
@@ -661,14 +657,14 @@ fn writer_thread(
     stop_flag: Arc<AtomicBool>,
     doc_counter: Arc<AtomicU64>,
 ) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     while !stop_flag.load(Ordering::Relaxed) {
         // Check if we should pause for verification
         stats.check_pause();
 
-        let collection = COLLECTIONS[rng.gen_range(0..COLLECTIONS.len())];
-        let roll: f64 = rng.gen();
+        let collection = COLLECTIONS[rng.random_range(0..COLLECTIONS.len())];
+        let roll: f64 = rng.random();
 
         if roll < INSERT_CHANCE {
             // INSERT
@@ -843,7 +839,7 @@ fn writer_thread(
         }
 
         // Small sleep to avoid overwhelming
-        thread::sleep(Duration::from_micros(rng.gen_range(100..1000)));
+        thread::sleep(Duration::from_micros(rng.random_range(100..1000)));
     }
 }
 
@@ -854,16 +850,16 @@ fn reader_thread(
     stats: Arc<Stats>,
     stop_flag: Arc<AtomicBool>,
 ) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     while !stop_flag.load(Ordering::Relaxed) {
         // Check if we should pause for verification
         stats.check_pause();
 
-        let collection = COLLECTIONS[rng.gen_range(0..COLLECTIONS.len())];
+        let collection = COLLECTIONS[rng.random_range(0..COLLECTIONS.len())];
 
         // Random read pattern: either point read or small range
-        if rng.gen_bool(0.7) {
+        if rng.random_bool(0.7) {
             // Point read
             let maybe_id = {
                 let truth = truth.read().unwrap();
@@ -896,7 +892,7 @@ fn reader_thread(
             }
         }
 
-        thread::sleep(Duration::from_millis(rng.gen_range(10..100)));
+        thread::sleep(Duration::from_millis(rng.random_range(10..100)));
     }
 }
 


### PR DESCRIPTION
## Summary

Bump **`rand` from 0.8 to 0.9** (major version with intentional breaking renames) and migrate **every** call site to the new API. No pin-back, no partial migration.

## Why this major is “real”

rand 0.9 renames the everyday surface area used throughout this repo’s tests and examples:

| 0.8 | 0.9 |
| --- | --- |
| `thread_rng()` | `rand::rng()` |
| `Rng::gen` / `gen_range` / `gen_bool` | `random` / `random_range` / `random_bool` |
| `rand::distributions::…` | `rand::distr::…` |
| `seq::SliceRandom::choose` on slices | `seq::IndexedRandom` |
| Alphanumeric string gen via `sample_iter` | `SampleString::sample_string` (where used) |

## Files updated (all call sites)

**Tests:** `model_based`, `query_fuzzing`, `test_concurrent_insert`, `test_insert_delete_race`, `test_model_based_flaky_reproducer`, `test_detailed_race_logging`, `test_paranoid_soak`, `stress/concurrency`, `stress/mvcc`

**Examples:** `bench_all`, `bench_batch_reuse`, `bench_insert_only`, `bench_insert1000_like_go`

**Manifest / lock:** `Cargo.toml` (`rand = "0.9"`), `Cargo.lock`

**CI:** adds `.github/workflows/ci.yml` so the bump is validated in Actions (including example builds that also use rand).

## Test plan

- [x] Local smoke: compile the migrated test binaries / examples (`--no-run` / `cargo build --examples`)
- [ ] CI: `cargo test --lib` + all rand-touching integration tests + `cargo build --examples`

Laptop-friendly: full suite left to CI.